### PR TITLE
feat(socket): Added timeout to wait data from socket

### DIFF
--- a/src/Nats/Socket.php
+++ b/src/Nats/Socket.php
@@ -140,11 +140,15 @@ class Socket
      * Receives a message thought the stream.
      *
      * @param integer $len Number of bytes to receive.
-     *
+     * @param float   $timeout Overall timeout to receive data
      * @return string
      */
-    public function receive($len = 0)
+    public function receive($len = 0, $timeout = 0.0)
     {
+        if ($timeout > 0) {
+            $this->setTimeout($timeout);
+        }
+
         if ($len > 0) {
             $chunkSize     = $this->chunkSize;
             $line          = null;


### PR DESCRIPTION
There is issue with wait function when count of items is >1 and socket timeout every time flush time on every msg

Example:
```php
$conn->connect(1); // connect with 1 sec timeout
$conn->subscribe('chanName', function(Message $msg) {});

$conn->wait(3);
```

If we receive 3 messages with 0.8 sec interval then overall time will be 2.4 sec. In this fix this behavior was fixed

```php
$conn->connect(1); // connect with 1 sec timeout
$conn->subscribe('chanName', function(Message $msg) {});

$conn->waitWithTimeout(3, 1.0);
```